### PR TITLE
perf(db): trim MySQL idle RAM (perf_schema off + small buffer pool)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,11 @@ services:
     image: mysql:8.4
     container_name: ttc-mysql-dev
     restart: unless-stopped
+    # Trim MySQL 8's idle footprint (perf_schema + buffer pool) — small club DB. ~470M → ~250M.
+    command:
+      - --performance-schema=OFF
+      - --innodb-buffer-pool-size=64M
+      - --innodb-buffer-pool-instances=1
     environment:
       MYSQL_ROOT_PASSWORD: my-secret-pw
       MYSQL_DATABASE: ttc_aalst

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,12 @@ services:
   db:
     image: mysql:8.4
     restart: unless-stopped
+    # MySQL 8 idles ~470M; the bulk is performance_schema (allocated up front, never freed) +
+    # the default buffer pool. This is a small club DB — trim both. ~470M → ~250M per instance.
+    command:
+      - --performance-schema=OFF
+      - --innodb-buffer-pool-size=64M
+      - --innodb-buffer-pool-instances=1
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-my-secret-pw}
       MYSQL_DATABASE: ttc_aalst


### PR DESCRIPTION
## Summary
- MySQL 8 idles ~470 MB; the bulk is `performance_schema` (allocated up front, never freed until restart) plus the default InnoDB buffer pool.
- This is a small club DB — disable perf_schema and shrink the buffer pool. **~470 MB → ~250 MB per instance** (~440 MB back across prod + dev on apps-01).
- Same engine, **no data migration, no code change**, fully reversible (drop the `command:`).

Applied to both `docker-compose.yml` (Coolify: prod/dev/PR) and `docker-compose.dev.yml` (local).

## Test Plan
- [ ] Deploy to the Coolify **dev** tier; app boots, the DB connects, normal CRUD + Frenoy sync work
- [ ] Beszel shows the dev DB container dropped to ~250 MB
- [ ] Promote to prod; verify same
- [ ] Live `:3306` LAN connection still works

Deeper engine switch (MariaDB/SQLite) tracked in #299.