### PR TITLE
chore: preview-routing spike probe (throwaway)

### DIFF
--- a/.spike-preview-probe
+++ b/.spike-preview-probe
@@ -1,0 +1,1 @@
+throwaway: validating Coolify preview routing (https scheme spike). delete me.


### PR DESCRIPTION
Throwaway PR to fire the Coolify preview webhook for the https-scheme routing spike. Closed immediately, branch deleted. Do not merge.